### PR TITLE
Fix #11: Hamburger menu překryté search barem na mobilu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ export function Header() {
   return (
     <>
       {/* Navbar */}
-      <nav className="bg-white shadow-md" style={{ height: '72px' }}>
+      <nav className="bg-white shadow-md relative z-50" style={{ height: '72px' }}>
         <div className="max-w-6xl mx-auto px-6 lg:px-10 h-full flex items-center justify-between">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-2.5 no-underline shrink-0">


### PR DESCRIPTION
Nav má fixní výšku 72px a mobilní menu přetéká ven, ale bez z-indexu ho překrývá následující search bar div. Přidáno relative z-50 na nav, aby menu bylo vždy navrchu.

https://claude.ai/code/session_017dGS5qXbaUQXPkacpkp8kp