### PR TITLE
Oprava ikon formátů: M↓ pro Markdown, { } pro JSON

### DIFF
--- a/src/app/skola/[slug]/page.tsx
+++ b/src/app/skola/[slug]/page.tsx
@@ -372,14 +372,14 @@ export default async function SchoolDetailPage({ params }: Props) {
                   href={`/skola/${overviewSlug}.md`}
                   className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
                 >
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /></svg>
+                  <span className="font-bold leading-none">M&#8595;</span>
                   Markdown
                 </a>
                 <a
                   href={`/skola/${overviewSlug}.json`}
                   className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
                 >
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
+                  <span className="font-mono leading-none">&#123; &#125;</span>
                   JSON
                 </a>
               </div>
@@ -523,14 +523,14 @@ export default async function SchoolDetailPage({ params }: Props) {
                 href={`/skola/${slug}.md`}
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
               >
-                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /></svg>
+                <span className="font-bold leading-none">M&#8595;</span>
                 Markdown
               </a>
               <a
                 href={`/skola/${slug}.json`}
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
               >
-                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
+                <span className="font-mono leading-none">&#123; &#125;</span>
                 JSON
               </a>
             </div>
@@ -916,14 +916,14 @@ export default async function SchoolDetailPage({ params }: Props) {
               href={`/skola/${overviewSlug}.md`}
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
             >
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /></svg>
+              <span className="font-bold leading-none">M&#8595;</span>
               Markdown
             </a>
             <a
               href={`/skola/${overviewSlug}.json`}
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-slate-200 hover:border-slate-300 hover:text-slate-600 transition-colors"
             >
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>
+              <span className="font-mono leading-none">&#123; &#125;</span>
               JSON
             </a>
           </div>


### PR DESCRIPTION
SVG ikony nahrazeny přiléhavějšími textovými symboly:
- M↓ (neoficiální logo Markdownu) místo generické ikony dokumentu
- { } (JSON závorky) místo </> (XML)

https://claude.ai/code/session_017dGS5qXbaUQXPkacpkp8kp