### PR TITLE
fix: oprava gramatických chyb (převys → převis, Rychlé → Rychlá fakta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Formát vychází z [Keep a Changelog](https://keepachangelog.com/cs/1.1.0/).
 
 ### Přidáno
 - **Nejžádanější studijní obory** (`/skoly`) — přepracovaná stránka se 3 taby:
-  - Nejžádanější obory 2026 (top 100 podle převysu poptávky)
+  - Nejžádanější obory 2026 (top 100 podle převisu poptávky)
   - Obtížnost přijetí 2025 (top 100 podle indexu obtížnosti)
-  - Převys poptávky podle měst 2026 (agregace za města s vizuálními bary a odkazy na školy)
+  - Převis poptávky podle měst 2026 (agregace za města s vizuálními bary a odkazy na školy)
 - **Granulární filtry typů škol** — výběr Gymnázia 4L/6L/8L, SOŠ, Lycea, SOU na přehledu měst
 - **2026 data jako primární** na kartě školy — přihlášky, místa a poptávka 2026 zobrazeny jako hlavní čísla, 2025 data jako sekundární
 - **Oddělení oborů z roku 2025** — obory bez pokračování v 2026 ve vlastní sekci „Obory z roku 2025"

--- a/src/app/skoly/page.tsx
+++ b/src/app/skoly/page.tsx
@@ -96,7 +96,7 @@ export default async function SchoolsPage() {
               <div className="text-3xl font-bold text-blue-600">
                 {totalKapacita2026 > 0 ? (totalPrihlasky2026 / totalKapacita2026).toFixed(1) : '—'}×
               </div>
-              <div className="text-sm text-slate-600">Prům. převys 2026</div>
+              <div className="text-sm text-slate-600">Prům. převis 2026</div>
             </div>
           </div>
 

--- a/src/components/SchoolsPageTabs.tsx
+++ b/src/components/SchoolsPageTabs.tsx
@@ -485,7 +485,7 @@ export function SchoolsPageTabs({ schools }: SchoolsPageTabsProps) {
                     </span>
                     <span className="text-slate-500">{s.obec}</span>
                     <span className="ml-auto text-slate-700 font-medium">min. {s.min_body}b</span>
-                    <span className="text-slate-500">{s.index_poptavky.toFixed(1)}× převys</span>
+                    <span className="text-slate-500">{s.index_poptavky.toFixed(1)}× převis</span>
                   </div>
                 </div>
               );

--- a/src/components/school/overview/QuickFactsCard.tsx
+++ b/src/components/school/overview/QuickFactsCard.tsx
@@ -27,7 +27,7 @@ export function QuickFactsCard({ facts, className }: QuickFactsCardProps) {
   return (
     <div className={`bg-white p-6 rounded-xl shadow-sm ${className || ""}`}>
       <h2 className="text-xl font-semibold mb-4 text-slate-900">
-        Rychlé fakta
+        Rychlá fakta
       </h2>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {facts.map((fact, index) => (


### PR DESCRIPTION
## Summary
- Oprava „převys" → „převis" ve 3 souborech (skoly/page.tsx, SchoolsPageTabs.tsx, CHANGELOG.md)
- Oprava „Rychlé fakta" → „Rychlá fakta" v QuickFactsCard.tsx

Fixes #51

## Test plan
- [ ] Ověřit stránku `/skoly` – text „Prům. převis 2026"
- [ ] Ověřit detail školy – sekce „Rychlá fakta"
- [ ] Ověřit tab obtížnosti – text „× převis"

https://claude.ai/code/session_01TSRT4TbAFiP4oAKZehpv4B