### PR TITLE
fix: plné názvy gymnázií v žebříčku + persistentní filtry

### DIFF
--- a/src/app/vysledky/[year]/ResultsClient.tsx
+++ b/src/app/vysledky/[year]/ResultsClient.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import Link from 'next/link';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import type { SchoolResult } from '@/lib/data';
+
+function displayName(r: SchoolResult): string {
+  return r.nazev_display || r.nazev;
+}
 
 const TYP_LABELS: Record<string, string> = {
   GY8: 'Gymnázia 8letá',
@@ -183,8 +188,10 @@ function RankingSection({ results, activeType, onTypeChange }: {
             >
               <span className="text-slate-400 font-bold text-sm w-6 text-center">#{i + 1}</span>
               <div className="flex-1 min-w-0">
-                <div className="font-semibold text-slate-800 truncate group-hover:text-slate-900">{r.nazev}</div>
-                <div className="text-xs text-slate-400">{r.kraj}</div>
+                <div className="font-semibold text-slate-800 truncate group-hover:text-slate-900">{displayName(r)}</div>
+                <div className="text-xs text-slate-400">
+                  {r.zamereni && <span>{r.zamereni} · </span>}{r.kraj}
+                </div>
               </div>
               <div className="text-right shrink-0">
                 <div className="text-lg font-black text-slate-900">{r.cj_ma_prijati.toFixed(1)}</div>
@@ -264,7 +271,8 @@ function SearchSection({ results, kraje, searchQuery, setSearchQuery, filterType
       .filter(r => {
         if (!searchQuery) return true;
         const q = searchQuery.toLowerCase();
-        return r.nazev.toLowerCase().includes(q) || r.kraj.toLowerCase().includes(q);
+        const name = (r.nazev_display || r.nazev).toLowerCase();
+        return name.includes(q) || r.nazev.toLowerCase().includes(q) || r.kraj.toLowerCase().includes(q) || (r.zamereni && r.zamereni.toLowerCase().includes(q));
       })
       .sort((a, b) => b.cj_ma_prijati - a.cj_ma_prijati)
       .slice(0, 100),
@@ -311,8 +319,10 @@ function SearchSection({ results, kraje, searchQuery, setSearchQuery, filterType
               className="flex items-center gap-4 bg-white border border-slate-200 rounded-xl px-4 py-3 hover:border-slate-400 transition-all"
             >
               <div className="flex-1 min-w-0">
-                <div className="font-medium text-slate-800 truncate">{r.nazev}</div>
-                <div className="text-xs text-slate-400">{TYP_LABELS[r.school_type] ?? r.school_type} · {r.kraj}</div>
+                <div className="font-medium text-slate-800 truncate">{displayName(r)}</div>
+                <div className="text-xs text-slate-400">
+                  {r.zamereni && <span>{r.zamereni} · </span>}{TYP_LABELS[r.school_type] ?? r.school_type} · {r.kraj}
+                </div>
               </div>
               <div className="text-right shrink-0">
                 <div className="font-bold text-slate-900">{r.cj_ma_prijati.toFixed(1)} b</div>
@@ -336,10 +346,40 @@ export function ResultsClient({
   totalKapacita,
   totalPrijati,
 }: Props) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [filterType, setFilterType] = useState('');
-  const [filterKraj, setFilterKraj] = useState('');
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [searchQuery, setSearchQueryState] = useState(searchParams.get('q') || '');
+  const [filterType, setFilterTypeState] = useState(searchParams.get('typ') || '');
+  const [filterKraj, setFilterKrajState] = useState(searchParams.get('kraj') || '');
   const [rankingType, setRankingType] = useState('GY4');
+
+  const updateParams = useCallback((key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    const qs = params.toString();
+    router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
+  }, [searchParams, router, pathname]);
+
+  const setSearchQuery = useCallback((v: string) => {
+    setSearchQueryState(v);
+    updateParams('q', v);
+  }, [updateParams]);
+
+  const setFilterType = useCallback((v: string) => {
+    setFilterTypeState(v);
+    updateParams('typ', v);
+  }, [updateParams]);
+
+  const setFilterKraj = useCallback((v: string) => {
+    setFilterKrajState(v);
+    updateParams('kraj', v);
+  }, [updateParams]);
 
   const kraje = useMemo(
     () => [...new Set(results.map(r => r.kraj).filter(Boolean))].sort(),

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1590,6 +1590,7 @@ export interface SchoolResult {
   kkov: string;
   zamereni: string;
   nazev: string;
+  nazev_display?: string;
   kraj: string;
   school_type: string;
   kapacita: number;
@@ -1959,6 +1960,25 @@ export async function getResultsForYear(year: number): Promise<Map<string, Schoo
     const filePath = path.join(dataDir, `cermat_results_${year}.json`);
     const content = await fs.readFile(filePath, 'utf-8');
     const raw = JSON.parse(content) as Record<string, SchoolResult>;
+
+    // Enrich with nazev_display from schools_data.json
+    const schoolsData = await getSchoolsData();
+    const yearData: Array<Record<string, unknown>> = (schoolsData as Record<string, unknown>)['2025'] as Array<Record<string, unknown>> || [];
+    const displayNameByRedizo = new Map<string, string>();
+    for (const s of yearData) {
+      const redizo = s.redizo as string;
+      const nd = s.nazev_display as string;
+      if (redizo && nd && !displayNameByRedizo.has(redizo)) {
+        displayNameByRedizo.set(redizo, nd);
+      }
+    }
+    for (const result of Object.values(raw)) {
+      const displayName = displayNameByRedizo.get(result.redizo);
+      if (displayName) {
+        result.nazev_display = displayName;
+      }
+    }
+
     const map = new Map(Object.entries(raw));
     resultsYearCache.set(year, map);
     return map;


### PR DESCRIPTION
## Summary

- **#63**: 205 gymnázií v CERMAT datech mělo generický název "Gymnázium" bez rozlišení (např. v top 30 GY4 bylo 15× "Gymnázium, Hlavní město Praha"). Nyní se obohacují o `nazev_display` ze `schools_data.json` (např. "Gymnázium, Botičská"). Také se v žebříčku a vyhledávání zobrazuje zaměření.
- **#60**: Filtry (typ školy, kraj, hledaný text) na stránce `/vysledky/2026` se resetovaly při navigaci na detail školy a zpět. Nyní se ukládají do URL query parametrů (`?typ=GY4&kraj=...`), takže přežijí navigaci zpět.

## Changes

- `src/lib/data.ts`: Přidáno `nazev_display` do `SchoolResult` interface; `getResultsForYear()` obohacuje výsledky o lepší názvy ze `schools_data.json`
- `src/app/vysledky/[year]/ResultsClient.tsx`: Použití `nazev_display` v žebříčku a vyhledávání; filtry persistovány v URL pomocí `useSearchParams`

## Test plan

- [ ] Otevřít `/vysledky/2026` a ověřit, že gymnázia v žebříčku mají specifické názvy (ne jen "Gymnázium")
- [ ] Ověřit, že zaměření se zobrazuje pod názvem školy
- [ ] Nastavit filtr typu a kraje, prokliknout na detail školy, vrátit se zpět — filtry by měly zůstat
- [ ] Ověřit, že URL obsahuje query parametry po nastavení filtrů
- [ ] Vyhledat "Botičská" ve vyhledávání — mělo by najít gymnázium

Closes #63, Closes #60

https://claude.ai/code/session_018pYM5GkXSR36tNy15hZoLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018pYM5GkXSR36tNy15hZoLq)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Toto PR řeší dva problémy: zobrazování generických názvů gymnázií v žebříčku (přidáním pole `nazev_display` obohaceného ze `schools_data.json`) a reset filtrů při navigaci zpět (persistencí filtrů do URL query parametrů pomocí `useSearchParams`).

- `src/lib/data.ts`: Funkce `getResultsForYear` po načtení CERMAT dat doplní `nazev_display` pro každou školu; rok pro vyhledávání je napevno `'2025'`.
- `src/app/vysledky/[year]/ResultsClient.tsx`: Filtry jsou synchronizovány s URL přes `router.replace`, ale chybí `<Suspense>` boundary a je zde riziko zastaralého stavu při rychlých aktualizacích.

<h3>Confidence Score: 3/5</h3>

PR je funkční pro nejběžnější scénáře, ale chybějící Suspense boundary může způsobit degradaci SSR a rychlé změny filtrů mohou vést ke ztrátě URL parametrů.

Komponenta ResultsClient volá useSearchParams() bez nadřazené Suspense hranice — Next.js App Router v takovém případě odhlásí celý segment od serverového streamování. Navíc updateParams čte searchParams z uzávěru a při rychlé změně dvou filtrů může druhé volání router.replace přepsat výsledky prvního.

src/app/vysledky/[year]/ResultsClient.tsx vyžaduje pozornost — přidání Suspense boundary v page.tsx a úprava logiky updateParams

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/data.ts | Přidává `nazev_display` do `SchoolResult` a obohacuje výsledky ze `schools_data.json`; rok pro vyhledávání názvů je napevno `'2025'` |
| src/app/vysledky/[year]/ResultsClient.tsx | Přidává persistenci filtrů přes URL params a zobrazuje `nazev_display`; chybí `Suspense` boundary a je zde riziko zastaralého stavu při rychlých aktualizacích filtrů |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fapp%2Fvysledky%2F%5Byear%5D%2FResultsClient.tsx%3A346-386%0A**Chyb%C4%9Bj%C3%ADc%C3%AD%20%60Suspense%60%20boundary%20pro%20%60useSearchParams%60**%0A%0A%60ResultsClient%60%20nyn%C3%AD%20vol%C3%A1%20%60useSearchParams%28%29%60%2C%20ale%20v%20%60page.tsx%60%20nen%C3%AD%20obalen%20%C5%BE%C3%A1dnou%20%60%3CSuspense%3E%60%20hranic%C3%AD.%20V%20Next.js%20App%20Routeru%20tato%20situace%20zp%C5%AFsob%C3%AD%2C%20%C5%BEe%20cel%C3%BD%20serverov%C3%BD%20segment%20str%C3%A1nky%20se%20odhl%C3%A1s%C3%AD%20od%20streamovan%C3%A9ho%20SSR%20a%20p%C5%99ejde%20na%20%C4%8Dist%C4%9B%20client-side%20rendering%20%E2%80%94%20u%C5%BEivatel%20uvid%C3%AD%20pr%C3%A1zdnou%20str%C3%A1nku%20a%C5%BE%20do%20hydratace.%20Next.js%20v%20buildu%20zobraz%C3%AD%20varov%C3%A1n%C3%AD%20a%20v%20%60next%20build%60%20s%20%60--strict%60%20m%C5%AF%C5%BEe%20selhat.%20Opravte%20obalen%C3%ADm%20%60%3CResultsClient%3E%60%20do%20%60%3CSuspense%20fallback%3D%7Bnull%7D%3E%60%20v%20%60page.tsx%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fapp%2Fvysledky%2F%5Byear%5D%2FResultsClient.tsx%3A357-372%0A**Mo%C5%BEn%C3%A1%20ztr%C3%A1ta%20filtr%C5%AF%20p%C5%99i%20rychl%C3%A9%20zm%C4%9Bn%C4%9B%20v%C3%ADce%20parametr%C5%AF**%0A%0A%60updateParams%60%20%C4%8Dte%20%60searchParams%60%20ze%20z%C3%A1v%C4%9Bru%20%28%60useCallback%60%20closure%29.%20Pokud%20u%C5%BEivatel%20zm%C4%9Bn%C3%AD%20typ%20%C5%A1koly%20a%20kraj%20t%C4%9Bsn%C4%9B%20za%20sebou%20%E2%80%94%20p%C5%99ed%20t%C3%ADm%2C%20ne%C5%BE%20se%20str%C3%A1nka%20znovu%20vykresl%C3%AD%20s%20nov%C3%BDmi%20URL%20parametry%20%E2%80%94%20druh%C3%A9%20vol%C3%A1n%C3%AD%20%60router.replace%60%20p%C5%99ep%C3%AD%C5%A1e%20aktualizaci%20prvn%C3%ADho%2C%20proto%C5%BEe%20ob%C4%9B%20%C4%8Dtou%20ze%20stejn%C3%BDch%20star%C3%BDch%20%60searchParams%60.%20Nap%C5%99%C3%ADklad%3A%20typ%20%E2%86%92%20%60%3Ftyp%3DGY4%60%2C%20pak%20kraj%20%28ze%20zastaral%C3%BDch%20params%29%20%E2%86%92%20%60%3Fkraj%3DPraha%60%2C%20v%C3%BDsledek%3A%20typ%20filter%20se%20ztrat%C3%AD.%20Opravte%20%C4%8Dten%C3%ADm%20%60params%60%20z%20aktu%C3%A1ln%C3%ADho%20URL%20nebo%20p%C5%99ed%C3%A1v%C3%A1n%C3%ADm%20aktualiz%C3%A1toru%20s%20funkcion%C3%A1ln%C3%AD%20formou.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Flib%2Fdata.ts%3A1966%0A**Napevno%20zak%C3%B3dovan%C3%BD%20rok%20%60'2025'%60%20pro%20obohacen%C3%AD%20n%C3%A1zv%C5%AF**%0A%0A%60getResultsForYear%28year%29%60%20v%C5%BEdy%20hled%C3%A1%20display%20names%20v%20%60schoolsData%5B'2025'%5D%60%2C%20bez%20ohledu%20na%20po%C5%BEadovan%C3%BD%20rok.%20Pro%20budouc%C3%AD%20roky%20%282027%2B%29%20se%20bude%20st%C3%A1le%20sahat%20do%20dat%20z%20roku%202025%2C%20co%C5%BE%20m%C5%AF%C5%BEe%20vr%C3%A1tit%20zastaral%C3%A9%20nebo%20chyb%C4%9Bj%C3%ADc%C3%AD%20n%C3%A1zvy.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20schoolsDataRaw%20%3D%20schoolsData%20as%20Record%3Cstring%2C%20Array%3CRecord%3Cstring%2C%20unknown%3E%3E%3E%3B%0A%20%20%20%20const%20availableDataYears%20%3D%20Object.keys%28schoolsDataRaw%29.map%28Number%29.sort%28%28a%2C%20b%29%20%3D%3E%20b%20-%20a%29%3B%0A%20%20%20%20const%20bestYear%20%3D%20availableDataYears.find%28y%20%3D%3E%20y%20%3C%3D%20year%29%20%3F%3F%20availableDataYears%5B0%5D%3B%0A%20%20%20%20const%20yearData%3A%20Array%3CRecord%3Cstring%2C%20unknown%3E%3E%20%3D%20%28bestYear%20%3F%20schoolsDataRaw%5BString%28bestYear%29%5D%20%3A%20null%29%20%3F%3F%20%5B%5D%3B%0A%60%60%60%0A%0A&repo=tangero%2Fstredniskoly&pr=68&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/app/vysledky/[year]/ResultsClient.tsx:346-386
**Chybějící `Suspense` boundary pro `useSearchParams`**

`ResultsClient` nyní volá `useSearchParams()`, ale v `page.tsx` není obalen žádnou `<Suspense>` hranicí. V Next.js App Routeru tato situace způsobí, že celý serverový segment stránky se odhlásí od streamovaného SSR a přejde na čistě client-side rendering — uživatel uvidí prázdnou stránku až do hydratace. Next.js v buildu zobrazí varování a v `next build` s `--strict` může selhat. Opravte obalením `<ResultsClient>` do `<Suspense fallback={null}>` v `page.tsx`.

### Issue 2 of 3
src/app/vysledky/[year]/ResultsClient.tsx:357-372
**Možná ztráta filtrů při rychlé změně více parametrů**

`updateParams` čte `searchParams` ze závěru (`useCallback` closure). Pokud uživatel změní typ školy a kraj těsně za sebou — před tím, než se stránka znovu vykreslí s novými URL parametry — druhé volání `router.replace` přepíše aktualizaci prvního, protože obě čtou ze stejných starých `searchParams`. Například: typ → `?typ=GY4`, pak kraj (ze zastaralých params) → `?kraj=Praha`, výsledek: typ filter se ztratí. Opravte čtením `params` z aktuálního URL nebo předáváním aktualizátoru s funkcionální formou.

### Issue 3 of 3
src/lib/data.ts:1966
**Napevno zakódovaný rok `'2025'` pro obohacení názvů**

`getResultsForYear(year)` vždy hledá display names v `schoolsData['2025']`, bez ohledu na požadovaný rok. Pro budoucí roky (2027+) se bude stále sahat do dat z roku 2025, což může vrátit zastaralé nebo chybějící názvy.

```suggestion
    const schoolsDataRaw = schoolsData as Record<string, Array<Record<string, unknown>>>;
    const availableDataYears = Object.keys(schoolsDataRaw).map(Number).sort((a, b) => b - a);
    const bestYear = availableDataYears.find(y => y <= year) ?? availableDataYears[0];
    const yearData: Array<Record<string, unknown>> = (bestYear ? schoolsDataRaw[String(bestYear)] : null) ?? [];
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: zobrazit plné názvy gymnázií v žebř..."](https://github.com/tangero/stredniskoly/commit/464fb90f6ca2521f8bcd54705fe79cc7dc3991bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32555782)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->